### PR TITLE
Use test fixtures

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,5 +12,6 @@
     "hfs"
   ],
   "python.testing.unittestEnabled": false,
-  "python.testing.pytestEnabled": true
+  "python.testing.pytestEnabled": true,
+  "makefile.configureOnOpen": false
 }

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,6 @@ mypy:
 	poetry run mypy hfs/
 
 pytest:
-	poetry run pytest hfs
+	poetry run pytest hfs/
 
 run-all: autolint pytest

--- a/hfs/preprocessing.py
+++ b/hfs/preprocessing.py
@@ -2,6 +2,8 @@
 Sklearn compatible estimators for preprocessing hierarchical data.
 """
 
+from __future__ import annotations
+
 import networkx as nx
 import numpy as np
 from networkx.algorithms.dag import ancestors

--- a/hfs/tests/conftest.py
+++ b/hfs/tests/conftest.py
@@ -1,5 +1,4 @@
 import math
-import random
 
 import networkx as nx
 import numpy as np

--- a/hfs/tests/conftest.py
+++ b/hfs/tests/conftest.py
@@ -12,7 +12,7 @@ from hfs.metrics import cosine_similarity
 
 
 @pytest.fixture()
-def data1():
+def data1(hierarchy1):
     X = np.array(
         [
             [0, 0, 0, 0, 1],
@@ -22,15 +22,14 @@ def data1():
             [1, 1, 1, 1, 1],
         ]
     )
-    hierarchy = hierarchy1()
-    columns = get_columns_for_numpy_hierarchy(hierarchy, X.shape[1])
-    hierarchy = nx.to_numpy_array(hierarchy)
+    columns = get_columns_for_numpy_hierarchy(hierarchy1, X.shape[1])
+    hierarchy = nx.to_numpy_array(hierarchy1)
     y = np.array([0, 0, 0, 0, 1])
     return (X, y, hierarchy, columns)
 
 
 @pytest.fixture()
-def data1_2():
+def data1_2(hierarchy1_2):
     X = np.array(
         [
             [0, 0, 0, 0, 1],
@@ -40,15 +39,14 @@ def data1_2():
             [1, 1, 1, 1, 1],
         ]
     )
-    hierarchy = hierarchy1_2()
-    columns = get_columns_for_numpy_hierarchy(hierarchy, X.shape[1])
-    hierarchy = nx.to_numpy_array(hierarchy)
+    columns = get_columns_for_numpy_hierarchy(hierarchy1_2, X.shape[1])
+    hierarchy = nx.to_numpy_array(hierarchy1_2)
     y = np.array([0, 0, 0, 0, 1])
     return (X, y, hierarchy, columns)
 
 
 @pytest.fixture()
-def data2():
+def data2(hierarchy2):
     X = np.array(
         [
             [1, 1, 0, 0, 1],
@@ -58,9 +56,8 @@ def data2():
             [1, 1, 0, 0, 0],
         ],
     )
-    hierarchy = hierarchy2()
-    columns = get_columns_for_numpy_hierarchy(hierarchy, X.shape[1])
-    hierarchy = nx.to_numpy_array(hierarchy)
+    columns = get_columns_for_numpy_hierarchy(hierarchy2, X.shape[1])
+    hierarchy = nx.to_numpy_array(hierarchy2)
     y = np.array([1, 0, 0, 1, 1])
     return (X, y, hierarchy, columns)
 
@@ -107,7 +104,7 @@ def data2_2():
 
 
 @pytest.fixture()
-def data3():
+def data3(hierarchy3):
     X = np.array(
         [
             [1, 1, 0, 0, 1],
@@ -118,9 +115,8 @@ def data3():
         ],
     )
 
-    hierarchy = hierarchy3()
-    columns = get_columns_for_numpy_hierarchy(hierarchy, X.shape[1])
-    hierarchy = nx.to_numpy_array(hierarchy)
+    columns = get_columns_for_numpy_hierarchy(hierarchy3, X.shape[1])
+    hierarchy = nx.to_numpy_array(hierarchy3)
     y = np.array([1, 0, 0, 1, 1])
     return (X, y, hierarchy, columns)
 
@@ -145,7 +141,7 @@ def data4():
 
 
 @pytest.fixture()
-def data_numerical():
+def data_numerical(hierarchy1):
     X = np.array(
         [
             [1, 6, 3, 0, 1],
@@ -155,9 +151,8 @@ def data_numerical():
             [1, 4, 1, 0, 3],
         ]
     )
-    hierarchy = hierarchy1()
-    columns = get_columns_for_numpy_hierarchy(hierarchy, X.shape[1])
-    hierarchy = nx.to_numpy_array(hierarchy)
+    columns = get_columns_for_numpy_hierarchy(hierarchy1, X.shape[1])
+    hierarchy = nx.to_numpy_array(hierarchy1)
     y = np.array([0, 0, 0, 0, 1])
     return (X, y, hierarchy, columns)
 
@@ -223,20 +218,20 @@ def result_tsel2():
 
 
 @pytest.fixture()
-def result_tsel3():
-    result = data3()[0]
+def result_tsel3(data3):
+    result = data3[0]
     support = np.array([True, True, True, True, True])
     return (result, support)
 
 
 @pytest.fixture()
-def result_shsel1():
-    return result_tsel1()
+def result_shsel1(result_tsel1):
+    return result_tsel1
 
 
 @pytest.fixture()
-def result_shsel_hfe1():
-    return result_shsel1()
+def result_shsel_hfe1(result_shsel1):
+    return result_shsel1
 
 
 @pytest.fixture()
@@ -285,14 +280,14 @@ def result_shsel_hfe4():
 
 
 @pytest.fixture()
-def result_shsel3():
-    return result_tsel3()
+def result_shsel3(result_tsel3):
+    return result_tsel3
 
 
 @pytest.fixture()
-def data_shsel_selection():
-    X = data2()[0]
-    y = data2()[1]
+def data_shsel_selection(data2):
+    X = data2[0]
+    y = data2[1]
     edges = [(0, 1), (1, 2), (2, 3), (3, 4)]
     hierarchy = nx.to_numpy_array(nx.DiGraph(edges))
     columns = None
@@ -475,7 +470,7 @@ def result_comparison_matrix_td1():
     )
 
 
-@pytest.fixture()
+# TODO maybe move to helper
 def result_comparison_matrix_bu(matrix: np.ndarray):
     result = np.zeros((5, 5))
     for x in range(5):
@@ -485,9 +480,8 @@ def result_comparison_matrix_bu(matrix: np.ndarray):
 
 
 @pytest.fixture()
-def result_comparison_matrix_bu1():
-    matrix = result_score_matrix1()
-    return result_comparison_matrix_bu(matrix)
+def result_comparison_matrix_bu1(result_score_matrix1):
+    return result_comparison_matrix_bu(result_score_matrix1)
 
 
 @pytest.fixture()
@@ -528,9 +522,8 @@ def result_score_matrix2():
 
 
 @pytest.fixture()
-def result_comparison_matrix_bu2():
-    matrix = result_score_matrix2()
-    return result_comparison_matrix_bu(matrix)
+def result_comparison_matrix_bu2(result_score_matrix2):
+    return result_comparison_matrix_bu(result_score_matrix2)
 
 
 @pytest.fixture()
@@ -547,9 +540,8 @@ def result_score_matrix3():
 
 
 @pytest.fixture()
-def result_comparison_matrix_bu3():
-    matrix = result_score_matrix3()
-    return result_comparison_matrix_bu(matrix)
+def result_comparison_matrix_bu3(result_score_matrix3):
+    return result_comparison_matrix_bu(result_score_matrix3)
 
 
 @pytest.fixture()
@@ -602,43 +594,13 @@ def result_aggregated2():
     )
 
 
-# TODO should this be capitalised if its a constant?
-_feature_number = 9
-
-
 # TODO is this a fixture or a method? if method move to helpers?
-def getFixedDag():
+def get_fixed_dag():
     return nx.to_numpy_array(
         nx.DiGraph(
             [(0, 1), (0, 2), (0, 3), (1, 4), (1, 5), (4, 6), (4, 7), (3, 7), (5, 8)]
         )
     )
-
-
-# TODO what is this rand about? where is it used?
-def rand():
-    return random.getrandbits(1)
-
-
-def random_lines_with_assertions(y):
-    b = rand()
-    c = rand()
-    d = rand()
-    e = rand() if b == 1 else 0
-    f = rand() if b == 1 else 0
-    g = rand() if e * d == 1 else 0
-    h = rand() if e == 1 and d == 1 else 0
-    i = rand() if f == 1 else 0
-    return (1, b, c, d, e, f, g, h, i)
-
-
-# TODO not used anywhere?
-def get_fixed_data(instance_number):
-    df = pd.DataFrame(columns=[i for i in range(0, _feature_number)])
-    y = np.random.randint(0, 2, instance_number)
-    for row in range(0, instance_number):
-        df.loc[len(df)] = random_lines_with_assertions(y)
-    return df.to_numpy(), y
 
 
 @pytest.fixture()
@@ -726,6 +688,67 @@ def lazy_data3():
 
 @pytest.fixture()
 def lazy_data4():
-    big_DAG = getFixedDag()
+    big_DAG = get_fixed_dag()
     small_DAG = nx.to_numpy_array(nx.DiGraph([(0, 1), (0, 2), (1, 2), (1, 3)]))
     return small_DAG, big_DAG
+
+
+@pytest.fixture()
+def data1_preprocessing():
+    X = np.array([[0, 0, 1], [0, 1, 0], [1, 0, 0]])
+
+    edges = [(1, 3), (3, 2), (0, 4), (0, 1)]
+    hierarchy_original = nx.DiGraph(edges)
+    columns = get_columns_for_numpy_hierarchy(hierarchy_original, X.shape[1])
+    hierarchy_original = nx.to_numpy_array(hierarchy_original)
+    hierarchy_transformed = nx.to_numpy_array(nx.DiGraph([(1, 3), (3, 2), (0, 1)]))
+    X_transformed = np.array([[1, 1, 1, 1], [1, 1, 0, 0], [1, 0, 0, 0]])
+
+    return (X, X_transformed, hierarchy_original, columns, hierarchy_transformed)
+
+
+@pytest.fixture()
+def data2_preprocessing():
+    X = np.array([[0, 0, 1], [0, 1, 0], [0, 1, 0]])
+
+    edges = [(1, 2), (1, 3), (3, 4), (0, 1)]
+    hierarchy_original = nx.DiGraph(edges)
+    columns = get_columns_for_numpy_hierarchy(hierarchy_original, X.shape[1])
+    hierarchy_original = nx.to_numpy_array(hierarchy_original)
+    edges_tranformed = [(1, 2), (0, 1)]
+    hierarchy_transformed = nx.to_numpy_array(nx.DiGraph(edges_tranformed))
+    X_transformed = np.array([[1, 1, 1], [1, 1, 0], [1, 1, 0]])
+
+    return (X, X_transformed, hierarchy_original, columns, hierarchy_transformed)
+
+
+# currently only used for test_shrink_dag
+@pytest.fixture()
+def data3_preprocessing():
+    edges = [
+        ("GO:2001090", "GO:2001091"),
+        ("GO:2001090", "GO:2001092"),
+        ("GO:2001091", "GO:2001093"),
+        ("GO:2001091", "GO:2001094"),
+        ("GO:2001093", "GO:2001095"),
+    ]
+    #      0
+    #   1      2
+    # 3    4
+    # 5
+    hierarchy = nx.to_numpy_array(nx.DiGraph(edges))
+    X_identifiers = list([0, 1, 2, 4])
+    X = np.ones((2, len(X_identifiers)))
+    # in X there is 0,1,2,4
+    edges_transformed = [
+        ("GO:2001090", "GO:2001091"),
+        ("GO:2001090", "GO:2001092"),
+        ("GO:2001091", "GO:2001094"),
+    ]
+    h = nx.DiGraph(edges_transformed)
+
+    h.add_edge("ROOT", "GO:2001090")
+
+    hierarchy_transformed = nx.to_numpy_array(h)
+
+    return (X, hierarchy, hierarchy_transformed, X_identifiers)

--- a/hfs/tests/fixtures/conftest.py
+++ b/hfs/tests/fixtures/conftest.py
@@ -4,12 +4,14 @@ import random
 import networkx as nx
 import numpy as np
 import pandas as pd
+import pytest
 from info_gain.info_gain import info_gain, info_gain_ratio
 
 from hfs.helpers import get_columns_for_numpy_hierarchy
 from hfs.metrics import cosine_similarity
 
 
+@pytest.fixture()
 def data1():
     X = np.array(
         [
@@ -27,6 +29,7 @@ def data1():
     return (X, y, hierarchy, columns)
 
 
+@pytest.fixture()
 def data1_2():
     X = np.array(
         [
@@ -44,6 +47,7 @@ def data1_2():
     return (X, y, hierarchy, columns)
 
 
+@pytest.fixture()
 def data2():
     X = np.array(
         [
@@ -61,6 +65,7 @@ def data2():
     return (X, y, hierarchy, columns)
 
 
+@pytest.fixture()
 def data2_1():
     X = np.array(
         [
@@ -80,6 +85,7 @@ def data2_1():
     return (X, y, hierarchy, columns)
 
 
+@pytest.fixture()
 def data2_2():
     X = np.array(
         [
@@ -100,6 +106,7 @@ def data2_2():
     return (X, y, hierarchy, columns)
 
 
+@pytest.fixture()
 def data3():
     X = np.array(
         [
@@ -118,6 +125,7 @@ def data3():
     return (X, y, hierarchy, columns)
 
 
+@pytest.fixture()
 def data4():
     X = np.array(
         [
@@ -136,6 +144,7 @@ def data4():
     return (X, y, hierarchy, columns)
 
 
+@pytest.fixture()
 def data_numerical():
     X = np.array(
         [
@@ -153,27 +162,32 @@ def data_numerical():
     return (X, y, hierarchy, columns)
 
 
+@pytest.fixture()
 def hierarchy1():
     edges = [(0, 1), (1, 2), (0, 3), (0, 4)]
     return nx.DiGraph(edges)
 
 
+@pytest.fixture()
 def hierarchy1_2():
     edges = [(0, 4), (0, 3), (0, 1), (1, 2)]
     return nx.DiGraph(edges)
 
 
+@pytest.fixture()
 def hierarchy2():
     edges = [(0, 1), (1, 2), (2, 3), (0, 4)]
     return nx.DiGraph(edges)
 
 
+@pytest.fixture()
 def hierarchy3():
     hierarchy = nx.DiGraph()
     hierarchy.add_nodes_from([0, 1, 2, 3, 4])
     return hierarchy
 
 
+@pytest.fixture()
 def dataframe():
     return pd.DataFrame(
         {
@@ -186,12 +200,14 @@ def dataframe():
     )
 
 
+@pytest.fixture()
 def result_tsel1():
     result = np.array([[0], [0], [0], [0], [1]])
     support = np.array([True, False, False, False, False])
     return (result, support)
 
 
+@pytest.fixture()
 def result_tsel2():
     result = np.array(
         [
@@ -206,20 +222,24 @@ def result_tsel2():
     return (result, support)
 
 
+@pytest.fixture()
 def result_tsel3():
     result = data3()[0]
     support = np.array([True, True, True, True, True])
     return (result, support)
 
 
+@pytest.fixture()
 def result_shsel1():
     return result_tsel1()
 
 
+@pytest.fixture()
 def result_shsel_hfe1():
     return result_shsel1()
 
 
+@pytest.fixture()
 def result_shsel2():
     result = np.array(
         [
@@ -234,6 +254,7 @@ def result_shsel2():
     return (result, support)
 
 
+@pytest.fixture()
 def result_shsel_hfe2():
     result = np.array(
         [
@@ -248,6 +269,7 @@ def result_shsel_hfe2():
     return (result, support)
 
 
+@pytest.fixture()
 def result_shsel_hfe4():
     result = np.array(
         [
@@ -262,10 +284,12 @@ def result_shsel_hfe4():
     return (result, support)
 
 
+@pytest.fixture()
 def result_shsel3():
     return result_tsel3()
 
 
+@pytest.fixture()
 def data_shsel_selection():
     X = data2()[0]
     y = data2()[1]
@@ -275,6 +299,7 @@ def data_shsel_selection():
     return (X, y, hierarchy, columns)
 
 
+@pytest.fixture()
 def result_shsel_selection():
     result = np.array(
         [
@@ -289,6 +314,7 @@ def result_shsel_selection():
     return (result, support)
 
 
+@pytest.fixture()
 def result_gtd_selection2():
     result = np.array(
         [
@@ -303,6 +329,7 @@ def result_gtd_selection2():
     return (result, support)
 
 
+@pytest.fixture()
 def result_gtd_selection2_1():
     result = np.array(
         [
@@ -317,6 +344,7 @@ def result_gtd_selection2_1():
     return (result, support)
 
 
+@pytest.fixture()
 def result_gtd_selection2_2():
     result = np.array(
         [
@@ -331,6 +359,7 @@ def result_gtd_selection2_2():
     return (result, support)
 
 
+@pytest.fixture()
 def result_hill_selection_td():
     result = pd.DataFrame(
         [
@@ -345,6 +374,7 @@ def result_hill_selection_td():
     return (result, support)
 
 
+@pytest.fixture()
 def result_hill_selection_bu():
     k = 3
     result = np.array(
@@ -360,6 +390,7 @@ def result_hill_selection_bu():
     return (result, support, k)
 
 
+@pytest.fixture()
 def wrong_hierarchy_X():
     X = np.array([[0, 0, 0], [0, 0, 0], [0, 0, 0]])
     hierarchy = nx.to_numpy_array(nx.DiGraph([(0, 1)]))
@@ -367,6 +398,7 @@ def wrong_hierarchy_X():
     return (X, hierarchy, columns)
 
 
+@pytest.fixture()
 def wrong_hierarchy_X1():
     X = np.array([[0, 0, 0], [0, 0, 0], [0, 0, 0]])
     hierarchy = nx.to_numpy_array(nx.DiGraph([(0, 1), (1, 2), (3, 4), (0, 5)]))
@@ -374,6 +406,7 @@ def wrong_hierarchy_X1():
     return (X, hierarchy, columns)
 
 
+@pytest.fixture()
 def result_score_matrix1():
     return np.array(
         [
@@ -386,6 +419,7 @@ def result_score_matrix1():
     )
 
 
+@pytest.fixture()
 def result_score_matrix_numerical():
     return np.array(
         [
@@ -428,6 +462,7 @@ def result_score_matrix_numerical():
     )
 
 
+@pytest.fixture()
 def result_comparison_matrix_td1():
     return np.array(
         [
@@ -440,6 +475,7 @@ def result_comparison_matrix_td1():
     )
 
 
+@pytest.fixture()
 def result_comparison_matrix_bu(matrix: np.ndarray):
     result = np.zeros((5, 5))
     for x in range(5):
@@ -448,11 +484,13 @@ def result_comparison_matrix_bu(matrix: np.ndarray):
     return result
 
 
+@pytest.fixture()
 def result_comparison_matrix_bu1():
     matrix = result_score_matrix1()
     return result_comparison_matrix_bu(matrix)
 
 
+@pytest.fixture()
 def result_fitness_funtion_td1():
     alpha = 0.99
     doc1 = math.sqrt(22) / (1 + alpha * (math.sqrt(2) + math.sqrt(7) + math.sqrt(15)))
@@ -464,6 +502,7 @@ def result_fitness_funtion_td1():
     return doc1 + doc2 + doc3 + doc4 + doc5
 
 
+@pytest.fixture()
 def result_fitness_funtion_bu1():
     alpha = 3
     n = 5
@@ -475,6 +514,7 @@ def result_fitness_funtion_bu1():
     return (result, k)
 
 
+@pytest.fixture()
 def result_score_matrix2():
     return np.array(
         [
@@ -487,11 +527,13 @@ def result_score_matrix2():
     )
 
 
+@pytest.fixture()
 def result_comparison_matrix_bu2():
     matrix = result_score_matrix2()
     return result_comparison_matrix_bu(matrix)
 
 
+@pytest.fixture()
 def result_score_matrix3():
     return np.array(
         [
@@ -504,11 +546,13 @@ def result_score_matrix3():
     )
 
 
+@pytest.fixture()
 def result_comparison_matrix_bu3():
     matrix = result_score_matrix3()
     return result_comparison_matrix_bu(matrix)
 
 
+@pytest.fixture()
 def result_gr_values2():
     y = np.array([1, 0, 0, 1, 1])
     return [
@@ -520,6 +564,7 @@ def result_gr_values2():
     ]
 
 
+@pytest.fixture()
 def result_ig_values2():
     y = np.array([1, 0, 0, 1, 1])
     return [
@@ -531,6 +576,7 @@ def result_ig_values2():
     ]
 
 
+@pytest.fixture()
 def result_aggregated1():
     return np.array(
         [
@@ -543,6 +589,7 @@ def result_aggregated1():
     )
 
 
+@pytest.fixture()
 def result_aggregated2():
     return np.array(
         [
@@ -555,9 +602,11 @@ def result_aggregated2():
     )
 
 
+# TODO should this be capitalised if its a constant?
 _feature_number = 9
 
 
+# TODO is this a fixture or a method? if method move to helpers?
 def getFixedDag():
     return nx.to_numpy_array(
         nx.DiGraph(
@@ -566,11 +615,12 @@ def getFixedDag():
     )
 
 
+# TODO what is this rand about? where is it used?
 def rand():
     return random.getrandbits(1)
 
 
-def randomLinesWithAssertions(y):
+def random_lines_with_assertions(y):
     b = rand()
     c = rand()
     d = rand()
@@ -582,14 +632,16 @@ def randomLinesWithAssertions(y):
     return (1, b, c, d, e, f, g, h, i)
 
 
-def getFixedData(instance_number):
+# TODO not used anywhere?
+def get_fixed_data(instance_number):
     df = pd.DataFrame(columns=[i for i in range(0, _feature_number)])
     y = np.random.randint(0, 2, instance_number)
     for row in range(0, instance_number):
-        df.loc[len(df)] = randomLinesWithAssertions(y)
+        df.loc[len(df)] = random_lines_with_assertions(y)
     return df.to_numpy(), y
 
 
+@pytest.fixture()
 def lazy_data1():
     edges = [
         (9, 3),
@@ -627,6 +679,7 @@ def lazy_data1():
     )
 
 
+@pytest.fixture()
 def lazy_data2():
     small_DAG = nx.to_numpy_array(nx.DiGraph([(0, 1), (0, 2), (1, 2), (1, 3)]))
     train_x_data = np.array([[1, 1, 0, 1], [1, 0, 0, 0], [1, 1, 1, 0], [1, 1, 1, 1]])
@@ -636,6 +689,7 @@ def lazy_data2():
     return (small_DAG, train_x_data, train_y_data, test_x_data, test_y_data)
 
 
+@pytest.fixture()
 def lazy_data3():
     edges = [(4, 0), (0, 3), (2, 3), (5, 2), (5, 1)]
     hierarchy = nx.DiGraph(edges)
@@ -670,6 +724,7 @@ def lazy_data3():
     )
 
 
+@pytest.fixture()
 def lazy_data4():
     big_DAG = getFixedDag()
     small_DAG = nx.to_numpy_array(nx.DiGraph([(0, 1), (0, 2), (1, 2), (1, 3)]))

--- a/hfs/tests/test_data_utils.py
+++ b/hfs/tests/test_data_utils.py
@@ -5,8 +5,6 @@ import pytest
 
 from hfs.data_utils import create_mapping_columns_to_nodes, load_data, process_data
 
-from .fixtures.fixtures import dataframe, hierarchy1, hierarchy1_2, hierarchy2, hierarchy3
-
 
 def remove_created_files():
     dirname = os.path.dirname(__file__)
@@ -35,13 +33,15 @@ def test_load_data():
 @pytest.mark.parametrize(
     "hierarchy, dataframe",
     [
-        (hierarchy1(), dataframe()),
-        (hierarchy1_2(), dataframe()),
-        (hierarchy2(), dataframe()),
-        (hierarchy3(), dataframe()),
+        ("hierarchy1", "dataframe"),
+        ("hierarchy1_2", "dataframe"),
+        ("hierarchy2", "dataframe"),
+        ("hierarchy3", "dataframe"),
     ],
 )
-def test_create_mapping_columns_to_nodes(hierarchy, dataframe):
+def test_create_mapping_columns_to_nodes(hierarchy, dataframe, request):
+    hierarchy = request.getfixturevalue(hierarchy)
+    dataframe = request.getfixturevalue(dataframe)
     mapping = create_mapping_columns_to_nodes(dataframe, hierarchy)
     nodes = list(hierarchy.nodes)
     for index, node in enumerate(dataframe.columns):

--- a/hfs/tests/test_data_utils.py
+++ b/hfs/tests/test_data_utils.py
@@ -31,17 +31,16 @@ def test_load_data():
 
 
 @pytest.mark.parametrize(
-    "hierarchy, dataframe",
+    "hierarchy",
     [
-        ("hierarchy1", "dataframe"),
-        ("hierarchy1_2", "dataframe"),
-        ("hierarchy2", "dataframe"),
-        ("hierarchy3", "dataframe"),
+        "hierarchy1",
+        "hierarchy1_2",
+        "hierarchy2",
+        "hierarchy3",
     ],
 )
 def test_create_mapping_columns_to_nodes(hierarchy, dataframe, request):
     hierarchy = request.getfixturevalue(hierarchy)
-    dataframe = request.getfixturevalue(dataframe)
     mapping = create_mapping_columns_to_nodes(dataframe, hierarchy)
     nodes = list(hierarchy.nodes)
     for index, node in enumerate(dataframe.columns):

--- a/hfs/tests/test_feature_selection.py
+++ b/hfs/tests/test_feature_selection.py
@@ -2,14 +2,13 @@ import pytest
 
 from hfs.selectors import EagerHierarchicalFeatureSelector
 
-from .fixtures.fixtures import wrong_hierarchy_X, wrong_hierarchy_X1
-
 
 @pytest.mark.parametrize(
     "data",
-    [wrong_hierarchy_X(), wrong_hierarchy_X1()],
+    ["wrong_hierarchy_X", "wrong_hierarchy_X1"],
 )
-def test_EagerHierarchicalFeatureSelector(data):
+def test_EagerHierarchicalFeatureSelector(data, request):
+    data = request.getfixturevalue(data)
     X, hierarchy, columns = data
     selector = EagerHierarchicalFeatureSelector(hierarchy)
     with pytest.warns(UserWarning):

--- a/hfs/tests/test_feature_selection_filter.py
+++ b/hfs/tests/test_feature_selection_filter.py
@@ -9,8 +9,6 @@ from hfs.selectors.mr import MR
 from hfs.selectors.rnb import RNB
 from hfs.selectors.tan import TAN
 
-from .fixtures.fixtures import lazy_data1, lazy_data2, lazy_data3
-
 
 @pytest.fixture
 def data1():
@@ -74,15 +72,9 @@ def data2():
     return (hierarchy, X_train_ones, X_train, y_train, X_test, resulted_features)
 
 
-@pytest.mark.parametrize(
-    "data",
-    [
-        lazy_data2(),
-    ],
-)
 # Test feature selection of HNB
-def test_HNB(data):
-    small_DAG, train_x_data, train_y_data, test_x_data, test_y_data = data
+def test_HNB(lazy_data2):
+    small_DAG, train_x_data, train_y_data, test_x_data, test_y_data = lazy_data2
     selector = HNB(hierarchy=small_DAG, k=2)
     selector.fit_selector(X_train=train_x_data, y_train=train_y_data, X_test=test_x_data)
     pred = selector.select_and_predict(predict=True, saveFeatures=True)
@@ -94,15 +86,9 @@ def test_HNB(data):
     assert selector.get_score(test_y_data, pred)["sensitivityxspecificity"] == 0.0
 
 
-@pytest.mark.parametrize(
-    "data",
-    [
-        lazy_data2(),
-    ],
-)
 # Test feature selection of HNBs
-def test_HNBs(data):
-    small_DAG, train_x_data, train_y_data, test_x_data, test_y_data = data
+def test_HNBs(lazy_data2):
+    small_DAG, train_x_data, train_y_data, test_x_data, test_y_data = lazy_data2
     selector = HNBs(hierarchy=small_DAG)
     selector.fit_selector(X_train=train_x_data, y_train=train_y_data, X_test=test_x_data)
     pred = selector.select_and_predict(predict=True, saveFeatures=True)
@@ -114,15 +100,9 @@ def test_HNBs(data):
     assert selector.get_score(test_y_data, pred)["sensitivityxspecificity"] == 0.0
 
 
-@pytest.mark.parametrize(
-    "data",
-    [
-        lazy_data2(),
-    ],
-)
 # Test feature selection of RNB
-def test_RNB(data):
-    small_DAG, train_x_data, train_y_data, test_x_data, test_y_data = data
+def test_RNB(lazy_data2):
+    small_DAG, train_x_data, train_y_data, test_x_data, test_y_data = lazy_data2
     selector = RNB(hierarchy=small_DAG, k=2)
     selector.fit_selector(X_train=train_x_data, y_train=train_y_data, X_test=test_x_data)
     pred = selector.select_and_predict(predict=True, saveFeatures=True)
@@ -130,15 +110,9 @@ def test_RNB(data):
     assert np.array_equal(selector.get_features(), np.array([[0, 1, 1, 0], [0, 1, 1, 0]]))
 
 
-@pytest.mark.parametrize(
-    "data",
-    [
-        lazy_data1(),
-    ],
-)
 # Test feature selection of MR
-def test_MR(data):
-    hierarchy, X_train, y_train, X_test, y_test, relevance = data
+def test_MR(lazy_data1):
+    hierarchy, X_train, y_train, X_test, y_test, relevance = lazy_data1
     selector = MR(nx.to_numpy_array(hierarchy))
     selector.fit_selector(X_train=X_train, y_train=y_train, X_test=X_test)
     selector._relevance = relevance
@@ -155,15 +129,9 @@ def test_MR(data):
     assert selector.get_score(y_test, pred)["sensitivityxspecificity"] == 0.0
 
 
-@pytest.mark.parametrize(
-    "data",
-    [
-        lazy_data1(),
-    ],
-)
 # Test feature selection of HIP
-def test_HIP(data):
-    hierarchy, X_train, y_train, X_test, y_test, relevance = data
+def test_HIP(lazy_data1):
+    hierarchy, X_train, y_train, X_test, y_test, relevance = lazy_data1
     selector = HIP(nx.to_numpy_array(hierarchy))
     selector.fit_selector(X_train=X_train, y_train=y_train, X_test=X_test)
     selector._relevance = relevance
@@ -180,14 +148,16 @@ def test_HIP(data):
     assert selector.get_score(y_test, pred)["sensitivityxspecificity"] == 0.0
 
 
-@pytest.mark.parametrize(
-    "data",
-    [
-        lazy_data3(),
-    ],
-)
-def test_TAN(data):
-    hierarchy, X_train_ones, X_train, y_train, X_test, y_test, resulted_features = data
+def test_TAN(lazy_data3):
+    (
+        hierarchy,
+        X_train_ones,
+        X_train,
+        y_train,
+        X_test,
+        y_test,
+        resulted_features,
+    ) = lazy_data3
     selector = TAN(nx.to_numpy_array(hierarchy))
     selector.fit_selector(X_train=X_train_ones, y_train=y_train, X_test=X_test)
     selector._xtrain = X_train

--- a/hfs/tests/test_gtd.py
+++ b/hfs/tests/test_gtd.py
@@ -22,17 +22,13 @@ def test_greedy_top_down_selection(data, result, request):
     assert np.array_equal(support_mask, support)
 
 
-@pytest.mark.parametrize(
-    "data, result_redundant, result_not_redundant",
-    [("data2_2", "result_gtd_selection2_1", "result_gtd_selection2_2")],
-)
 def test_greedy_top_down_selection_dag(
-    data, result_redundant, result_not_redundant, request
+    data2_2,
+    result_gtd_selection2_1,
+    result_gtd_selection2_2,
 ):
-    data = request.getfixturevalue(data)
-    result_redundant = request.getfixturevalue(result_redundant)
-    X, y, hierarchy, columns = data
-    expected_redundant, support_redundant = result_redundant
+    X, y, hierarchy, columns = data2_2
+    expected_redundant, support_redundant = result_gtd_selection2_1
     selector = GreedyTopDownSelector(hierarchy)
     selector.fit(X, y, columns)
     X_transformed = selector.transform(X)
@@ -41,7 +37,7 @@ def test_greedy_top_down_selection_dag(
     support_mask = selector.get_support()
     assert np.array_equal(support_mask, support_redundant)
 
-    expected_not_redundant, support_not_redundant = result_not_redundant
+    expected_not_redundant, support_not_redundant = result_gtd_selection2_2
     selector2 = GreedyTopDownSelector(hierarchy, iterate_first_level=False)
     selector2.fit(X, y, columns)
     X_transformed2 = selector2.transform(X)

--- a/hfs/tests/test_gtd.py
+++ b/hfs/tests/test_gtd.py
@@ -3,21 +3,14 @@ import pytest
 
 from hfs.selectors import GreedyTopDownSelector
 
-from .fixtures.fixtures import (
-    data2,
-    data2_1,
-    data2_2,
-    result_gtd_selection2,
-    result_gtd_selection2_1,
-    result_gtd_selection2_2,
-)
-
 
 @pytest.mark.parametrize(
     "data, result",
-    [(data2(), result_gtd_selection2()), (data2_1(), result_gtd_selection2_1())],
+    [("data2", "result_gtd_selection2"), ("data2_1", "result_gtd_selection2_1")],
 )
-def test_greedy_top_down_selection(data, result):
+def test_greedy_top_down_selection(data, result, request):
+    data = request.getfixturevalue(data)
+    result = request.getfixturevalue(result)
     X, y, hierarchy, columns = data
     expected, support = result
     selector = GreedyTopDownSelector(hierarchy)
@@ -31,9 +24,13 @@ def test_greedy_top_down_selection(data, result):
 
 @pytest.mark.parametrize(
     "data, result_redundant, result_not_redundant",
-    [(data2_2(), result_gtd_selection2_1(), result_gtd_selection2_2())],
+    [("data2_2", "result_gtd_selection2_1", "result_gtd_selection2_2")],
 )
-def test_greedy_top_down_selection_dag(data, result_redundant, result_not_redundant):
+def test_greedy_top_down_selection_dag(
+    data, result_redundant, result_not_redundant, request
+):
+    data = request.getfixturevalue(data)
+    result_redundant = request.getfixturevalue(result_redundant)
     X, y, hierarchy, columns = data
     expected_redundant, support_redundant = result_redundant
     selector = GreedyTopDownSelector(hierarchy)

--- a/hfs/tests/test_helpers.py
+++ b/hfs/tests/test_helpers.py
@@ -13,16 +13,6 @@ from ..helpers import (
     shrink_dag,
 )
 from ..metrics import gain_ratio, information_gain
-from .fixtures.fixtures import (
-    data1,
-    data2,
-    lazy_data2,
-    lazy_data4,
-    result_aggregated1,
-    result_aggregated2,
-    result_gr_values2,
-    result_ig_values2,
-)
 
 
 def test_shrink_dag():
@@ -75,14 +65,8 @@ def test_shrink_dag():
         assert not (node in graph.nodes())
 
 
-@pytest.mark.parametrize(
-    "data",
-    [
-        lazy_data4(),
-    ],
-)
-def test_connect_dag(data):
-    small_DAG, big_DAG = data
+def test_connect_dag(lazy_data4):
+    small_DAG, big_DAG = lazy_data4
     graph = nx.DiGraph(big_DAG)
     x_identifiers = [0, 1, 2, 5, 6, 7, 8]
     graph = connect_dag(hierarchy=graph, x_identifiers=x_identifiers)
@@ -90,52 +74,36 @@ def test_connect_dag(data):
     assert nx.is_isomorphic(graph, new_graph)
 
 
-@pytest.mark.parametrize(
-    "data",
-    [
-        lazy_data2(),
-    ],
-)
-def test_relevance(data):
-    small_DAG, train_x_data, train_y_data, test_x_data, test_y_data = data
+def test_relevance(lazy_data2):
+    small_DAG, train_x_data, train_y_data, test_x_data, test_y_data = lazy_data2
     results = [Fraction(1, 2), Fraction(8, 9), 2, 0]
     for node_idx in range(len(small_DAG)):
         value = get_relevance(train_x_data, train_y_data, node_idx)
         assert value == results[node_idx]
 
 
-@pytest.mark.parametrize(
-    "data, result",
-    [
-        (data2(), result_ig_values2()),
-    ],
-)
-def test_information_gain(data, result):
-    X, y, _, _ = data
+def test_information_gain(data2, result_ig_values2):
+    X, y, _, _ = data2
     ig = information_gain(X, y)
-    assert ig == result
+    assert ig == result_ig_values2
 
 
-@pytest.mark.parametrize(
-    "data, result",
-    [
-        (data2(), result_gr_values2()),
-    ],
-)
-def test_gain_ratio(data, result):
-    X, y, _, _ = data
+def test_gain_ratio(data2, result_gr_values2):
+    X, y, _, _ = data2
     gr = gain_ratio(X, y)
-    assert result == gr
+    assert gr == result_gr_values2
 
 
 @pytest.mark.parametrize(
     "data, result",
     [
-        (data1(), result_aggregated1()),
-        (data2(), result_aggregated2()),
+        ("data1", "result_aggregated1"),
+        ("data2", "result_aggregated2"),
     ],
 )
-def test_compute_aggregated_values(data, result):
+def test_compute_aggregated_values(data, result, request):
+    data = request.getfixturevalue(data)
+    result = request.getfixturevalue(result)
     X, _, hierarchy, columns = data
     hierarchy = create_hierarchy(nx.DiGraph(hierarchy))
     X_transformed = compute_aggregated_values(X, hierarchy, columns)

--- a/hfs/tests/test_hie_aode.py
+++ b/hfs/tests/test_hie_aode.py
@@ -1,33 +1,18 @@
 import networkx as nx
 import numpy as np
-import pytest
 
 from hfs.selectors import HieAODE
 
-from .fixtures.fixtures import lazy_data2
 
-
-@pytest.mark.parametrize(
-    "data",
-    [
-        lazy_data2(),
-    ],
-)
-def test_hie_aode(data):
-    small_DAG, train_x_data, train_y_data, test_x_data, test_y_data = data
+def test_hie_aode(lazy_data2):
+    small_DAG, train_x_data, train_y_data, test_x_data, _ = lazy_data2
     selector = HieAODE(hierarchy=small_DAG)
     selector.fit_selector(X_train=train_x_data, y_train=train_y_data, X_test=test_x_data)
     _ = selector.select_and_predict(predict=True, saveFeatures=True)
 
 
-@pytest.mark.parametrize(
-    "data",
-    [
-        lazy_data2(),
-    ],
-)
-def test_calculate_dependency_ascendant_class(data):
-    small_DAG, train_x_data, train_y_data, test_x_data, test_y_data = data
+def test_calculate_dependency_ascendant_class(lazy_data2):
+    small_DAG, train_x_data, train_y_data, test_x_data, _ = lazy_data2
     selector = HieAODE(hierarchy=small_DAG)
     selector.fit_selector(X_train=train_x_data, y_train=train_y_data, X_test=test_x_data)
     feature_idx = 2

--- a/hfs/tests/test_hill_climbing.py
+++ b/hfs/tests/test_hill_climbing.py
@@ -3,35 +3,17 @@ import pytest
 
 from hfs.selectors.hill_climbing import BottomUpSelector, TopDownSelector
 
-from .fixtures.fixtures import (
-    data1,
-    data1_2,
-    data2,
-    data3,
-    data_numerical,
-    result_comparison_matrix_bu1,
-    result_comparison_matrix_bu2,
-    result_comparison_matrix_bu3,
-    result_comparison_matrix_td1,
-    result_fitness_funtion_bu1,
-    result_fitness_funtion_td1,
-    result_hill_selection_bu,
-    result_hill_selection_td,
-    result_score_matrix1,
-    result_score_matrix2,
-    result_score_matrix3,
-    result_score_matrix_numerical,
-)
-
 
 @pytest.mark.parametrize(
     "data, result",
     [
-        (data1(), result_hill_selection_td()),
-        (data1_2(), result_hill_selection_td()),
+        ("data1", "result_hill_selection_td"),
+        ("data1_2", "result_hill_selection_td"),
     ],
 )
-def test_top_down_selection(data, result):
+def test_top_down_selection(data, result, request):
+    data = request.getfixturevalue(data)
+    result = request.getfixturevalue(result)
     X, y, hierarchy, columns = data
     expected, support = result
     selector = TopDownSelector(hierarchy, dataset_type="binary")
@@ -39,19 +21,13 @@ def test_top_down_selection(data, result):
     X = selector.transform(X)
     assert np.array_equal(X, expected)
 
-    support_mask = selector.get_support()
+    support_mask = selector.get_support
     assert np.array_equal(support_mask, support)
 
 
-@pytest.mark.parametrize(
-    "data, result",
-    [
-        (data1(), result_hill_selection_bu()),
-    ],
-)
-def test_bottom_up_selection(data, result):
-    X, y, hierarchy, columns = data
-    expected, support, k = result
+def test_bottom_up_selection(data1, result_hill_selection_bu):
+    X, y, hierarchy, columns = data1
+    expected, support, k = result_hill_selection_bu
     selector = BottomUpSelector(hierarchy, k=k, dataset_type="binary")
     selector.fit(X, y, columns)
     X = selector.transform(X)
@@ -61,15 +37,9 @@ def test_bottom_up_selection(data, result):
     assert np.array_equal(support_mask, support)
 
 
-@pytest.mark.parametrize(
-    "data, result",
-    [
-        (data1(), result_hill_selection_bu()),
-    ],
-)
-def test_bottom_up_selection_numerical(data, result):
-    X, y, hierarchy, columns = data
-    expected, support, k = result
+def test_bottom_up_selection_numerical(data1, result_hill_selection_bu):
+    X, y, hierarchy, columns = data1
+    expected, support, k = result_hill_selection_bu
     selector = BottomUpSelector(hierarchy, k=k, dataset_type="numerical")
     selector.fit(X, y, columns)
     X = selector.transform(X)
@@ -82,12 +52,14 @@ def test_bottom_up_selection_numerical(data, result):
 @pytest.mark.parametrize(
     "data, result",
     [
-        (data1(), result_score_matrix1()),
-        (data2(), result_score_matrix2()),
-        (data3(), result_score_matrix3()),
+        ("data1", "result_score_matrix1"),
+        ("data2", "result_score_matrix2"),
+        ("data3", "result_score_matrix3"),
     ],
 )
-def test_calculate_scores(data, result):
+def test_calculate_scores(data, result, request):
+    data = request.getfixturevalue(data)
+    result = request.getfixturevalue(result)
     X, y, hierarchy, columns = data
     score_matrix_expected = result
 
@@ -98,15 +70,9 @@ def test_calculate_scores(data, result):
     assert np.array_equal(score_matrix, score_matrix_expected)
 
 
-@pytest.mark.parametrize(
-    "data, result",
-    [
-        (data_numerical(), result_score_matrix_numerical()),
-    ],
-)
-def test_calculate_scores_numerical(data, result):
-    X, y, hierarchy, columns = data
-    score_matrix_expected = result
+def test_calculate_scores_numerical(data_numerical, result_score_matrix_numerical):
+    X, y, hierarchy, columns = data_numerical
+    score_matrix_expected = result_score_matrix_numerical
 
     selector = TopDownSelector(hierarchy, dataset_type="numerical")
     selector.fit(X, y, columns)
@@ -118,13 +84,15 @@ def test_calculate_scores_numerical(data, result):
 @pytest.mark.parametrize(
     "data, result, Selector",
     [
-        (data1(), result_comparison_matrix_td1(), TopDownSelector),
-        (data1(), result_comparison_matrix_bu1(), BottomUpSelector),
-        (data2(), result_comparison_matrix_bu2(), BottomUpSelector),
-        (data3(), result_comparison_matrix_bu3(), BottomUpSelector),
+        ("data1", "result_comparison_matrix_td1", TopDownSelector),
+        ("data1", "result_comparison_matrix_bu1", BottomUpSelector),
+        ("data2", "result_comparison_matrix_bu2", BottomUpSelector),
+        ("data3", "result_comparison_matrix_bu3", BottomUpSelector),
     ],
 )
-def test_comparison_matrix(data, result, Selector):
+def test_comparison_matrix(data, result, Selector, request):
+    data = request.getfixturevalue(data)
+    result = request.getfixturevalue(result)
     X, y, hierarchy, columns = data
     comparison_matrix_expected = result
 
@@ -135,45 +103,29 @@ def test_comparison_matrix(data, result, Selector):
     assert np.array_equal(comparison_matrix, comparison_matrix_expected)
 
 
-@pytest.mark.parametrize(
-    "data, comparison_matrix, result",
-    [
-        (
-            data1(),
-            result_comparison_matrix_bu1(),
-            result_fitness_funtion_bu1(),
-        ),
-    ],
-)
-def test_calculate_fitness_function_bu(data, comparison_matrix, result):
-    X, y, hierarchy, columns = data
+def test_calculate_fitness_function_bu(
+    data1, result_comparison_matrix_bu1, result_fitness_funtion_bu1
+):
+    X, y, hierarchy, columns = data1
 
-    fitness_expected, k = result
+    fitness_expected, k = result_fitness_funtion_bu1
 
     selector = BottomUpSelector(hierarchy, k=k)
     selector.fit(X, y, columns)
-    fitness = selector._fitness_function(comparison_matrix)
+    fitness = selector._fitness_function(result_comparison_matrix_bu1)
 
     assert np.array_equal(fitness, fitness_expected)
 
 
-@pytest.mark.parametrize(
-    "data, comparison_matrix, result",
-    [
-        (
-            data1(),
-            result_comparison_matrix_td1(),
-            result_fitness_funtion_td1(),
-        )
-    ],
-)
-def test_calculate_fitness_function_td(data, comparison_matrix, result):
-    X, y, hierarchy, columns = data
+def test_calculate_fitness_function_td(
+    data1, result_comparison_matrix_td1, result_fitness_funtion_td1
+):
+    X, y, hierarchy, columns = data1
 
-    fitness_expected = result
+    fitness_expected = result_fitness_funtion_td1
 
     selector = TopDownSelector(hierarchy)
     selector.fit(X, y, columns)
-    fitness = selector._fitness_function(comparison_matrix)
+    fitness = selector._fitness_function(result_comparison_matrix_td1)
 
     assert np.array_equal(fitness, fitness_expected)

--- a/hfs/tests/test_hill_climbing.py
+++ b/hfs/tests/test_hill_climbing.py
@@ -5,23 +5,19 @@ from hfs.selectors.hill_climbing import BottomUpSelector, TopDownSelector
 
 
 @pytest.mark.parametrize(
-    "data, result",
-    [
-        ("data1", "result_hill_selection_td"),
-        ("data1_2", "result_hill_selection_td"),
-    ],
+    "data",
+    ["data1", "data1_2"],
 )
-def test_top_down_selection(data, result, request):
+def test_top_down_selection(data, result_hill_selection_td, request):
     data = request.getfixturevalue(data)
-    result = request.getfixturevalue(result)
     X, y, hierarchy, columns = data
-    expected, support = result
+    expected, support = result_hill_selection_td
     selector = TopDownSelector(hierarchy, dataset_type="binary")
     selector.fit(X, y, columns)
     X = selector.transform(X)
     assert np.array_equal(X, expected)
 
-    support_mask = selector.get_support
+    support_mask = selector.get_support()
     assert np.array_equal(support_mask, support)
 
 

--- a/hfs/tests/test_preprocessing.py
+++ b/hfs/tests/test_preprocessing.py
@@ -6,34 +6,34 @@ from hfs.data_utils import create_mapping_columns_to_nodes, load_data
 from hfs.helpers import get_columns_for_numpy_hierarchy
 from hfs.preprocessing import HierarchicalPreprocessor
 
+# def data1():
+#     X = np.array([[0, 0, 1], [0, 1, 0], [1, 0, 0]])
 
-def data1():
-    X = np.array([[0, 0, 1], [0, 1, 0], [1, 0, 0]])
+#     edges = [(1, 3), (3, 2), (0, 4), (0, 1)]
+#     hierarchy_original = nx.DiGraph(edges)
+#     columns = get_columns_for_numpy_hierarchy(hierarchy_original, X.shape[1])
+#     hierarchy_original = nx.to_numpy_array(hierarchy_original)
+#     hierarchy_transformed = nx.to_numpy_array(nx.DiGraph([(1, 3), (3, 2), (0, 1)]))
+#     X_transformed = np.array([[1, 1, 1, 1], [1, 1, 0, 0], [1, 0, 0, 0]])
 
-    edges = [(1, 3), (3, 2), (0, 4), (0, 1)]
-    hierarchy_original = nx.DiGraph(edges)
-    columns = get_columns_for_numpy_hierarchy(hierarchy_original, X.shape[1])
-    hierarchy_original = nx.to_numpy_array(hierarchy_original)
-    hierarchy_transformed = nx.to_numpy_array(nx.DiGraph([(1, 3), (3, 2), (0, 1)]))
-    X_transformed = np.array([[1, 1, 1, 1], [1, 1, 0, 0], [1, 0, 0, 0]])
-
-    return (X, X_transformed, hierarchy_original, columns, hierarchy_transformed)
-
-
-def data2():
-    X = np.array([[0, 0, 1], [0, 1, 0], [0, 1, 0]])
-
-    edges = [(1, 2), (1, 3), (3, 4), (0, 1)]
-    hierarchy_original = nx.DiGraph(edges)
-    columns = get_columns_for_numpy_hierarchy(hierarchy_original, X.shape[1])
-    hierarchy_original = nx.to_numpy_array(hierarchy_original)
-    edges_tranformed = [(1, 2), (0, 1)]
-    hierarchy_transformed = nx.to_numpy_array(nx.DiGraph(edges_tranformed))
-    X_transformed = np.array([[1, 1, 1], [1, 1, 0], [1, 1, 0]])
-
-    return (X, X_transformed, hierarchy_original, columns, hierarchy_transformed)
+#     return (X, X_transformed, hierarchy_original, columns, hierarchy_transformed)
 
 
+# def data2():
+#     X = np.array([[0, 0, 1], [0, 1, 0], [0, 1, 0]])
+
+#     edges = [(1, 2), (1, 3), (3, 4), (0, 1)]
+#     hierarchy_original = nx.DiGraph(edges)
+#     columns = get_columns_for_numpy_hierarchy(hierarchy_original, X.shape[1])
+#     hierarchy_original = nx.to_numpy_array(hierarchy_original)
+#     edges_tranformed = [(1, 2), (0, 1)]
+#     hierarchy_transformed = nx.to_numpy_array(nx.DiGraph(edges_tranformed))
+#     X_transformed = np.array([[1, 1, 1], [1, 1, 0], [1, 1, 0]])
+
+#     return (X, X_transformed, hierarchy_original, columns, hierarchy_transformed)
+
+
+# currently only used for test_shrink_dag
 @pytest.fixture
 def data3():
     edges = [
@@ -67,9 +67,10 @@ def data3():
 
 @pytest.mark.parametrize(
     "data",
-    [data1(), data2()],
+    ["data1", "data2"],
 )
-def test_HP(data):
+def test_hierarchical_preprocessor(data, request):
+    request.getfixturevalue(data)
     X, X_transformed, hierarchy, columns, hierarchy_expected = data
 
     preprocessor = HierarchicalPreprocessor(hierarchy)
@@ -82,10 +83,12 @@ def test_HP(data):
     assert np.array_equal(hierarchy_transformed, hierarchy_expected)
 
 
-def test_shrink_dag(data3):
+# TODO rename to test_fit and update to check all submethods included in fit?
+def test_fit(data3):
     X, hierarchy, hierarchy_transformed, X_identifiers = data3
     preprocessor = HierarchicalPreprocessor(hierarchy)
     preprocessor.fit(X, columns=X_identifiers)
+    assert preprocessor.is_fitted_
     hierarchy = preprocessor.get_hierarchy()
     assert np.equal(hierarchy.all(), hierarchy_transformed.all())
 

--- a/hfs/tests/test_preprocessing.py
+++ b/hfs/tests/test_preprocessing.py
@@ -6,71 +6,13 @@ from hfs.data_utils import create_mapping_columns_to_nodes, load_data
 from hfs.helpers import get_columns_for_numpy_hierarchy
 from hfs.preprocessing import HierarchicalPreprocessor
 
-# def data1():
-#     X = np.array([[0, 0, 1], [0, 1, 0], [1, 0, 0]])
-
-#     edges = [(1, 3), (3, 2), (0, 4), (0, 1)]
-#     hierarchy_original = nx.DiGraph(edges)
-#     columns = get_columns_for_numpy_hierarchy(hierarchy_original, X.shape[1])
-#     hierarchy_original = nx.to_numpy_array(hierarchy_original)
-#     hierarchy_transformed = nx.to_numpy_array(nx.DiGraph([(1, 3), (3, 2), (0, 1)]))
-#     X_transformed = np.array([[1, 1, 1, 1], [1, 1, 0, 0], [1, 0, 0, 0]])
-
-#     return (X, X_transformed, hierarchy_original, columns, hierarchy_transformed)
-
-
-# def data2():
-#     X = np.array([[0, 0, 1], [0, 1, 0], [0, 1, 0]])
-
-#     edges = [(1, 2), (1, 3), (3, 4), (0, 1)]
-#     hierarchy_original = nx.DiGraph(edges)
-#     columns = get_columns_for_numpy_hierarchy(hierarchy_original, X.shape[1])
-#     hierarchy_original = nx.to_numpy_array(hierarchy_original)
-#     edges_tranformed = [(1, 2), (0, 1)]
-#     hierarchy_transformed = nx.to_numpy_array(nx.DiGraph(edges_tranformed))
-#     X_transformed = np.array([[1, 1, 1], [1, 1, 0], [1, 1, 0]])
-
-#     return (X, X_transformed, hierarchy_original, columns, hierarchy_transformed)
-
-
-# currently only used for test_shrink_dag
-@pytest.fixture
-def data3():
-    edges = [
-        ("GO:2001090", "GO:2001091"),
-        ("GO:2001090", "GO:2001092"),
-        ("GO:2001091", "GO:2001093"),
-        ("GO:2001091", "GO:2001094"),
-        ("GO:2001093", "GO:2001095"),
-    ]
-    #      0
-    #   1      2
-    # 3    4
-    # 5
-    hierarchy = nx.to_numpy_array(nx.DiGraph(edges))
-    X_identifiers = list([0, 1, 2, 4])
-    X = np.ones((2, len(X_identifiers)))
-    # in X there is 0,1,2,4
-    edges_transformed = [
-        ("GO:2001090", "GO:2001091"),
-        ("GO:2001090", "GO:2001092"),
-        ("GO:2001091", "GO:2001094"),
-    ]
-    h = nx.DiGraph(edges_transformed)
-
-    h.add_edge("ROOT", "GO:2001090")
-
-    hierarchy_transformed = nx.to_numpy_array(h)
-
-    return (X, hierarchy, hierarchy_transformed, X_identifiers)
-
 
 @pytest.mark.parametrize(
     "data",
-    ["data1", "data2"],
+    ["data1_preprocessing", "data2_preprocessing"],
 )
 def test_hierarchical_preprocessor(data, request):
-    request.getfixturevalue(data)
+    data = request.getfixturevalue(data)
     X, X_transformed, hierarchy, columns, hierarchy_expected = data
 
     preprocessor = HierarchicalPreprocessor(hierarchy)
@@ -84,8 +26,8 @@ def test_hierarchical_preprocessor(data, request):
 
 
 # TODO rename to test_fit and update to check all submethods included in fit?
-def test_fit(data3):
-    X, hierarchy, hierarchy_transformed, X_identifiers = data3
+def test_fit(data3_preprocessing):
+    X, hierarchy, hierarchy_transformed, X_identifiers = data3_preprocessing
     preprocessor = HierarchicalPreprocessor(hierarchy)
     preprocessor.fit(X, columns=X_identifiers)
     assert preprocessor.is_fitted_

--- a/hfs/tests/test_shsel.py
+++ b/hfs/tests/test_shsel.py
@@ -3,33 +3,19 @@ import pytest
 
 from hfs.selectors import SHSELSelector
 
-from .fixtures.fixtures import (
-    data1,
-    data1_2,
-    data2,
-    data3,
-    data4,
-    data_shsel_selection,
-    result_shsel1,
-    result_shsel2,
-    result_shsel3,
-    result_shsel_hfe1,
-    result_shsel_hfe2,
-    result_shsel_hfe4,
-    result_shsel_selection,
-)
-
 
 @pytest.mark.parametrize(
     "data, result",
     [
-        (data1(), result_shsel1()),
-        (data2(), result_shsel2()),
-        (data3(), result_shsel3()),
-        (data1_2(), result_shsel1()),
+        ("data1", "result_shsel1"),
+        ("data2", "result_shsel2"),
+        ("data3", "result_shsel3"),
+        ("data1_2", "result_shsel1"),
     ],
 )
-def test_SHSEL_selection(data, result):
+def test_SHSEL_selection(data, result, request):
+    data = request.getfixturevalue(data)
+    result = request.getfixturevalue(result)
     X, y, hierarchy, columns = data
     expected, support = result
     selector = SHSELSelector(hierarchy)
@@ -44,12 +30,14 @@ def test_SHSEL_selection(data, result):
 @pytest.mark.parametrize(
     "data, result",
     [
-        (data_shsel_selection(), result_shsel_selection()),
-        (data1(), result_shsel1()),
-        (data1_2(), result_shsel1()),
+        ("data_shsel_selection", "result_shsel_selection"),
+        ("data1", "result_shsel1"),
+        ("data1_2", "result_shsel1"),
     ],
 )
-def test_SHSEL_selection_with_initial_selection(data, result):
+def test_SHSEL_selection_with_initial_selection(data, result, request):
+    data = request.getfixturevalue(data)
+    result = request.getfixturevalue(result)
     X, y, hierarchy, columns = data
     expected, support = result
     selector = SHSELSelector(hierarchy, similarity_threshold=0.8)
@@ -64,12 +52,14 @@ def test_SHSEL_selection_with_initial_selection(data, result):
 @pytest.mark.parametrize(
     "data, result",
     [
-        (data1(), result_shsel_hfe1()),
-        (data2(), result_shsel_hfe2()),
-        (data4(), result_shsel_hfe4()),
+        ("data1", "result_shsel_hfe1"),
+        ("data2", "result_shsel_hfe2"),
+        ("data4", "result_shsel_hfe4"),
     ],
 )
-def test_leaf_filtering(data, result):
+def test_leaf_filtering(data, result, request):
+    data = request.getfixturevalue(data)
+    result = request.getfixturevalue(result)
     X, y, hierarchy, columns = data
     expected, support = result
     selector = SHSELSelector(hierarchy, use_hfe_extension=True)

--- a/hfs/tests/test_tsel.py
+++ b/hfs/tests/test_tsel.py
@@ -3,27 +3,19 @@ import pytest
 
 from hfs.selectors import TSELSelector
 
-from .fixtures.fixtures import (
-    data1,
-    data1_2,
-    data2,
-    data3,
-    result_tsel1,
-    result_tsel2,
-    result_tsel3,
-)
-
 
 @pytest.mark.parametrize(
     "data, result",
     [
-        (data1(), result_tsel1()),
-        (data2(), result_tsel2()),
-        (data3(), result_tsel3()),
-        (data1_2(), result_tsel1()),
+        ("data1", "result_tsel1"),
+        ("data2", "result_tsel2"),
+        ("data3", "result_tsel3"),
+        ("data1_2", "result_tsel1"),
     ],
 )
-def test_TSEL_selection(data, result):
+def test_TSEL_selection(data, result, request):
+    data = request.getfixturevalue(data)
+    result = request.getfixturevalue(result)
     X, y, hierarchy, columns = data
     expected, support = result
     selector = TSELSelector(hierarchy)


### PR DESCRIPTION
* renamed `tests/fixtures/fixtures.py` to `tests/conftest.py` because pytest collects fixtures automatically from files named `conftest.py`
* removed all imports from `fixtures.py` because they are now collected automatically
* made all test setup methods in `conftest.py` fixtures
* updated all tests to use the fixtures

closes #18 

todo before this PR can be merged:
* [x] waiting for #25