### PR TITLE
Changed order of multiple class inheritance to scikit-learn standard

### DIFF
--- a/hfs/selectors/base.py
+++ b/hfs/selectors/base.py
@@ -9,7 +9,7 @@ from sklearn.utils.validation import check_array
 from hfs.helpers import create_hierarchy
 
 
-class HierarchicalEstimator(BaseEstimator, TransformerMixin):
+class HierarchicalEstimator(TransformerMixin, BaseEstimator):
     """Base class for estimators using hierarchical data.
 
     The HierarchicalEstimator implements scikit-learn's BaseEstimator and

--- a/hfs/selectors/lazyHierarchicalFeatureSelector.py
+++ b/hfs/selectors/lazyHierarchicalFeatureSelector.py
@@ -10,7 +10,7 @@ from hfs.metrics import conditional_mutual_information
 from hfs.selectors import HierarchicalEstimator
 
 
-class LazyHierarchicalFeatureSelector(HierarchicalEstimator, ABC):
+class LazyHierarchicalFeatureSelector(ABC, HierarchicalEstimator):
     """
     Abstract class used for all lazy hierarchical feature selection methods.
 


### PR DESCRIPTION
See and double-check comment in issue regarding ABC class inheritance.

Closes issue #27 