### PR TITLE
Draft: Refactor shrink_dag()

### DIFF
--- a/hfs/helpers.py
+++ b/hfs/helpers.py
@@ -80,39 +80,6 @@ def check_data(dag, x_data, y_data):
                 )
 
 
-def get_irrelevant_leaves(x_identifier, digraph):
-    """Get leaves from the given graph that contain no relevant information.
-
-    A leaf is considered irrelevant if it meets the following criteria:
-    - It is not part of the specified x_identifier list.
-    - It is not the "ROOT" node, which typically represents the starting
-      node of the DAG.
-
-    Parameters
-    ----------
-    x_identifier :  list
-                    A list containing node identifiers that are considered
-                    relevant
-    digraph : networkx.DiGraph
-            The Directed Acyclic Graph (DAG) from which irrelevant leaves
-            will be identified.
-
-    Returns
-    ----------
-    selected_leaves : list
-                    A list of leaf nodes that contain no relevant information.
-    """
-    selected_leaves = [
-        x
-        for x in digraph.nodes()
-        if digraph.out_degree(x) == 0
-        and digraph.in_degree(x) == 1
-        and x not in x_identifier
-        and x != "ROOT"
-    ]
-    return selected_leaves
-
-
 def get_leaves(graph: nx.DiGraph):
     """Get the leaf nodes from the given directed acyclic graph (DAG).
 
@@ -140,7 +107,7 @@ def get_leaves(graph: nx.DiGraph):
     return leaves
 
 
-def shrink_dag(x_identifier, digraph):
+def shrink_dag(x_identifier: list, digraph: nx.DiGraph):
     """Remove irrelevant leaf nodes from the given DAG.
 
     Parameters
@@ -155,14 +122,48 @@ def shrink_dag(x_identifier, digraph):
     ----------
     digraph : networkx.DiGraph
             The resulting DAG after removing all irrelevant leaf nodes.
-
     """
-    leaves = get_irrelevant_leaves(x_identifier, digraph)
-    while leaves:
-        for x in leaves:
-            digraph.remove_node(x)
-        leaves = get_irrelevant_leaves(x_identifier, digraph)
+    to_remove = {
+        node
+        for node in digraph.nodes()
+        if _is_irrelevant_leaf(node, x_identifier, digraph)
+    }
+
+    while to_remove:
+        # Recompute the list of nodes to check (predecessors of removed nodes)
+        to_check = {pred for node in to_remove for pred in digraph.predecessors(node)}
+        digraph.remove_nodes_from(to_remove)
+        to_remove = {
+            node for node in to_check if _is_irrelevant_leaf(node, x_identifier, digraph)
+        }
+
     return digraph
+
+
+def _is_irrelevant_leaf(node, x_identifier, digraph):
+    """
+    Determine if a node is an irrelevant leaf in a directed acyclic graph (DAG).
+
+    A node is considered an irrelevant leaf if:
+    - It has no outgoing edges (i.e., it is a leaf node).
+    - It is not included in the specified list of relevant node identifiers (`x_identifier`).
+    - It is not the "ROOT" node
+
+    Parameters
+    ----------
+    node : Any
+        The node to evaluate.
+    x_identifier : list
+        A list of node identifiers that are considered relevant and should not be removed.
+    digraph : networkx.DiGraph
+        The directed acyclic graph (DAG) being analyzed.
+
+    Returns
+    ----------
+    bool
+        True if the node is an irrelevant leaf; otherwise, False.
+    """
+    return digraph.out_degree(node) == 0 and node != "ROOT" and node not in x_identifier
 
 
 def connect_dag(x_identifiers, hierarchy: nx.DiGraph):

--- a/hfs/preprocessing.py
+++ b/hfs/preprocessing.py
@@ -11,7 +11,7 @@ import numpy as np
 from networkx.algorithms.dag import ancestors
 from sklearn.utils.validation import check_array, check_is_fitted
 
-from hfs.helpers import get_irrelevant_leaves
+from hfs.helpers import shrink_dag
 from hfs.selectors import HierarchicalEstimator
 
 
@@ -163,22 +163,16 @@ class HierarchicalPreprocessor(HierarchicalEstimator):
             warnings.warn(warning_missing_nodes)
 
     def _shrink_dag(self):
-        """Unnecessary nodes are removed from the hierarchy graph.
+        """Irrelevant nodes are removed from the hierarchy graph.
 
-        Nodes are considered unnecessary if they do not have a corresponding
+        Nodes are considered irrelevant if they do not have a corresponding
         column in the input dataframe and don't have any children. These
         features would always be 0 in the dataset and, therefore, do not
         contain any necessary information.
         """
-        leaves = get_irrelevant_leaves(
-            x_identifier=self._columns, digraph=self._hierarchy_graph
-        )
-        while leaves:
-            for x in leaves:
-                self._hierarchy_graph.remove_node(x)
-            leaves = get_irrelevant_leaves(
-                x_identifier=self._columns, digraph=self._hierarchy_graph
-            )
+        x_identifier = self._columns
+        digraph = self._hierarchy_graph
+        self._hierarchy_graph = shrink_dag(x_identifier, digraph)
 
     def _find_missing_columns(self):
         """Finds nodes for which a column needs to be added to the dataset.

--- a/hfs/tests/test_helpers.py
+++ b/hfs/tests/test_helpers.py
@@ -1,68 +1,29 @@
-import os
 from fractions import Fraction
 
 import networkx as nx
 import numpy as np
 import pytest
 
-from ..helpers import (
+from hfs.helpers import (
     add_root_node,
     compute_aggregated_values,
     connect_dag,
     get_relevance,
     shrink_dag,
 )
-from ..metrics import gain_ratio, information_gain
+from hfs.metrics import gain_ratio, information_gain
 
 
 def test_shrink_dag():
-    dirname = os.path.dirname(__file__)
-    nodes = np.load(os.path.join(dirname, "../data/nodes_go.npy"))
-    graph = nx.read_gml(os.path.join(dirname, "../data/go_digraph.gml"))
+    edges = [(0, 1), (0, 2), (0, 4), (3, 4), (3, 5), (6, 1), (6, 4)]
+    graph = nx.DiGraph(edges)
+    x_identifiers = [1]
+    nodes_to_remove = [2, 3, 4, 5]
 
-    nonexist_nodes = [
-        "GO:2001301",
-        "GO:2001302",
-        "GO:2001303",
-        "GO:2001304",
-        "GO:2001305",
-        "GO:2001306",
-        "GO:2001307",
-        "GO:2001308",
-        "GO:2001309",
-        "GO:2001310",
-        "GO:2001311",
-        "GO:2001312",
-        "GO:2001313",
-        "GO:2001314",
-        "GO:2001315",
-        "GO:2001316",
-        "GO:2001092",
-        "GO:2001094",
-        "GO:2001106",
-        "GO:2001107",
-    ]  # 4 nodes that are leaves
-
-    x_identifiers = np.setdiff1d(nodes, nonexist_nodes)
-
-    # four nodes in non_existing_nodes can be removed as they are leaves
-    assert (
-        len(
-            [
-                x
-                for x in nonexist_nodes
-                if graph.out_degree(x) == 0 and graph.in_degree(x) == 1
-            ]
-        )
-        == 4
-    )
-
-    # test removal of the nodes
-    assert len(graph.nodes()) == 43008
+    assert len(graph.nodes()) == 7
     graph = shrink_dag(x_identifiers, graph)
-    assert len(graph.nodes()) == 43004
-    for node in ["GO:2001092", "GO:2001094", "GO:2001106", "GO:2001107"]:
-        assert not (node in graph.nodes())
+    assert len(graph.nodes()) == 3
+    assert all(node not in graph.nodes() for node in nodes_to_remove)
 
 
 def test_connect_dag(lazy_data4):


### PR DESCRIPTION
* replaced duplicate `_shrink_dag()` in `preprocessing.py` implementation with `shrink_dag` in `helpers.py`
* improved efficiency of implementation by only checking potential new leaves (predecessors of nodes that were removed) instead of all nodes in each iteration
* replaced slow test that was loading data with test data


Note: I removed the check for `in_degree == 1` because a leaf in a DAG can also have higher in_degree. (Compare with the unchanged implementation of `get_leaves()`.) If this check was actually intentional I'm of course happy to put it back.

todo:
* [ ] wait for merge of #36 