### PR TITLE
Check input DAG

### DIFF
--- a/hfs/helpers.py
+++ b/hfs/helpers.py
@@ -3,6 +3,7 @@ Collection of helper methods for the feature selection algorithms.
 """
 
 import math
+import warnings
 from fractions import Fraction
 
 import networkx as nx
@@ -231,8 +232,12 @@ def add_virtual_root_node(hierarchy: nx.DiGraph):
     roots = [x for x in hierarchy.nodes() if hierarchy.in_degree(x) == 0]
     # create parent node to join hierarchies
     hierarchy.add_node("ROOT")
-    for root_node in roots:
-        hierarchy.add_edge("ROOT", root_node)
+    if len(roots) > 1:
+        warnings.warn(
+            f"Hierarchy consists of multiple ({len(roots)}) disjoint hierarchies. "
+        )
+        for root_node in roots:
+            hierarchy.add_edge("ROOT", root_node)
     return hierarchy
 
 

--- a/hfs/helpers.py
+++ b/hfs/helpers.py
@@ -236,8 +236,8 @@ def add_virtual_root_node(hierarchy: nx.DiGraph):
         warnings.warn(
             f"Hierarchy consists of multiple ({len(roots)}) disjoint hierarchies. "
         )
-        for root_node in roots:
-            hierarchy.add_edge("ROOT", root_node)
+    for root_node in roots:
+        hierarchy.add_edge("ROOT", root_node)
     return hierarchy
 
 

--- a/hfs/preprocessing.py
+++ b/hfs/preprocessing.py
@@ -75,6 +75,7 @@ class HierarchicalPreprocessor(HierarchicalEstimator):
         if columns is None:
             self._columns = [-1] * self.n_features_in_
 
+        self._check_dag()
         self._extend_dag()
         self._shrink_dag()
         self._find_missing_columns()
@@ -128,6 +129,17 @@ class HierarchicalPreprocessor(HierarchicalEstimator):
             return nx.to_numpy_array(self._hierarchy_graph)
         else:
             raise RuntimeError("Instance has not been fitted.")
+
+    def _check_dag(self):
+        """Checks if the hierarchy graph is a directed acyclic graph.
+
+        Raises
+        ------
+        ValueError
+            If the hierarchy graph is not a directed acyclic graph.
+        """
+        if not nx.is_directed_acyclic_graph(self._hierarchy_graph):
+            raise ValueError("The hierarchy graph is not a directed acyclic graph.")
 
     def _extend_dag(self):
         """Adds missing nodes to the hierarchy graph.


### PR DESCRIPTION
* adds `_check_dag()` to raise error when input hierarchy is not a DAG
* adds warning to `add_root_note()` that gets raised when there are multiple components in hierarchy

todo:
* merge #39 


closes #29 
closes #7 