### PR TITLE
Update workflow versions

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -34,7 +34,7 @@ jobs:
       # Cache the installation of Poetry itself, e.g. the next step. This prevents the workflow
       # from installing Poetry every time, which can be slow.
       - name: cache poetry install
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.local
           key: poetry-1.7.1
@@ -58,7 +58,7 @@ jobs:
       # them in the cache key. I'm not, so it can be simple and just depend on the poetry.lock.
       - name: cache deps
         id: cache-deps
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: .venv
           key: pydeps-${{ hashFiles('**/poetry.lock') }}

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -13,7 +13,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: psf/black@stable
         with:
           # cannot use use_pyproject to use settings from pyproject.toml below python 3.11


### PR DESCRIPTION
We were using actions/cache@v2 in our workflows which will be removed soon. This PR updates to v4.
It also updates to actions/checkout@v4.

There is also currently a warning about an update of the ubuntu versions. However, we don't need to take any action because we use the ubuntu-latest tag. This means that we will automatically move to the newest version and there are no breaking changes for us. More info [here](https://github.com/actions/runner-images/issues/10636).

closes #45 